### PR TITLE
use alternative version of cpan-upload

### DIFF
--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -3,7 +3,7 @@
 @prefix : <http://ontologi.es/doap-deps#>.
 
 `Dist-Inkt-Role-Release`
-	:runtime-requirement    [ :on "CPAN::Uploader"^^:CpanId ];
+	:runtime-requirement    [ :on "Alt::CPAN::Uploader::tinyua"^^:CpanId ];
 	:runtime-requirement    [ :on "Dist::Inkt"^^:CpanId ];
 	:runtime-requirement    [ :on "Moose::Role"^^:CpanId ];
 	:runtime-requirement    [ :on "Types::Standard"^^:CpanId ];


### PR DESCRIPTION
`Alt::CPAN::Uploader::tinyua` installs a lighter version of `cpan-upload` script into the system;
it uses `HTTP::Tiny::*` family of modules instead of requiring the whole cruft of `libwww-perl`
